### PR TITLE
Add support for templating view data (fix #7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ vendor
 .phpunit.result.cache
 phpunit.xml
 var
+bin
+.php_cs
+.php_cs.cache

--- a/DependencyInjection/RompetompInertiaExtension.php
+++ b/DependencyInjection/RompetompInertiaExtension.php
@@ -26,7 +26,7 @@ class RompetompInertiaExtension extends ConfigurableExtension
      */
     protected function loadInternal(array $mergedConfig, ContainerBuilder $container)
     {
-        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yaml');
 
         $definition = $container->getDefinition('rompetomp_inertia.inertia');

--- a/EventListener/InertiaListener.php
+++ b/EventListener/InertiaListener.php
@@ -29,7 +29,7 @@ class InertiaListener
             return;
         }
 
-        if ($request->getMethod() === 'GET'
+        if ('GET' === $request->getMethod()
             && $request->headers->get('X-Inertia-Version') !== $this->inertia->getVersion()
         ) {
             $response = new Response('', 409, ['X-Inertia-Location' => $request->getUri()]);
@@ -43,7 +43,7 @@ class InertiaListener
             return;
         }
         if ($event->getResponse()->isRedirect()
-            && $event->getResponse()->getStatusCode() === 302
+            && 302 === $event->getResponse()->getStatusCode()
             && in_array($event->getRequest()->getMethod(), ['PUT', 'PATCH', 'DELETE'])
         ) {
             $event->getResponse()->setStatusCode(303);

--- a/Service/Inertia.php
+++ b/Service/Inertia.php
@@ -33,8 +33,8 @@ class Inertia implements InertiaInterface
      */
     public function __construct(string $rootView, Environment $engine, RequestStack $requestStack)
     {
-        $this->engine = $engine;
-        $this->rootView = $rootView;
+        $this->engine       = $engine;
+        $this->rootView     = $rootView;
         $this->requestStack = $requestStack;
     }
 
@@ -69,11 +69,11 @@ class Inertia implements InertiaInterface
 
     public function render($component, $props = []): Response
     {
-        $props = array_merge($this->sharedProps, $props);
+        $props   = array_merge($this->sharedProps, $props);
         $request = $this->requestStack->getCurrentRequest();
-        $url = $request->getRequestUri();
+        $url     = $request->getRequestUri();
 
-        $only = array_filter(explode(',', $request->headers->get('X-Inertia-Partial-Data')));
+        $only  = array_filter(explode(',', $request->headers->get('X-Inertia-Partial-Data')));
         $props = ($only && $request->headers->get('X-Inertia-Partial-Component') === $component)
             ? self::array_only($props, $only) : $props;
 
@@ -84,11 +84,11 @@ class Inertia implements InertiaInterface
         });
 
         $version = $this->version;
-        $page = compact('component', 'props', 'url', 'version');
+        $page    = compact('component', 'props', 'url', 'version');
 
         if ($request->headers->get('X-Inertia')) {
             return new JsonResponse($page, 200, [
-                'Vary' => 'Accept',
+                'Vary'      => 'Accept',
                 'X-Inertia' => true,
             ]);
         }

--- a/Service/Inertia.php
+++ b/Service/Inertia.php
@@ -18,6 +18,9 @@ class Inertia implements InertiaInterface
     /** @var array */
     protected $sharedProps = [];
 
+    /** @var array */
+    protected $sharedViewData = [];
+
     /** @var \Symfony\Component\HttpFoundation\RequestStack */
     protected $requestStack;
 
@@ -52,6 +55,20 @@ class Inertia implements InertiaInterface
         return $this->sharedProps;
     }
 
+    public function setViewData(string $key, $value = null): void
+    {
+        $this->sharedViewData[$key] = $value;
+    }
+
+    public function getViewData(string $key = null)
+    {
+        if ($key) {
+            return $this->sharedViewData[$key] ?? null;
+        }
+
+        return $this->sharedViewData;
+    }
+
     public function version(string $version): void
     {
         $this->version = $version;
@@ -67,8 +84,9 @@ class Inertia implements InertiaInterface
         return $this->rootView;
     }
 
-    public function render($component, $props = []): Response
+    public function render($component, $props = [], $view = []): Response
     {
+        $view = array_merge($this->sharedViewData, $view);
         $props   = array_merge($this->sharedProps, $props);
         $request = $this->requestStack->getCurrentRequest();
         $url     = $request->getRequestUri();
@@ -94,7 +112,7 @@ class Inertia implements InertiaInterface
         }
 
         $response = new Response();
-        $response->setContent($this->engine->render($this->rootView, compact('page')));
+        $response->setContent($this->engine->render($this->rootView, compact('page', 'view')));
 
         return $response;
     }

--- a/Service/InertiaInterface.php
+++ b/Service/InertiaInterface.php
@@ -29,6 +29,21 @@ interface InertiaInterface
     public function getShared(string $key = null);
 
     /**
+     * Adds global view data for the templating system.
+     *
+     * @param string $key
+     * @param mixed  $value
+     */
+    public function setViewData(string $key, $value = null): void;
+
+    /**
+     * @param string|null $key
+     *
+     * @return mixed
+     */
+    public function getViewData(string $key = null);
+
+    /**
      * @param string $version
      */
     public function version(string $version): void;
@@ -46,8 +61,9 @@ interface InertiaInterface
     /**
      * @param       $component Component name.
      * @param array $props     Component properties.
+     * @param array $view      Templating view data.
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function render($component, $props = []): Response;
+    public function render($component, $props = [], $view = []): Response;
 }

--- a/Service/InertiaInterface.php
+++ b/Service/InertiaInterface.php
@@ -14,6 +14,8 @@ use Symfony\Component\HttpFoundation\Response;
 interface InertiaInterface
 {
     /**
+     * Adds global component properties for the templating system.
+     *
      * @param string $key
      * @param mixed  $value
      */
@@ -42,8 +44,8 @@ interface InertiaInterface
     public function getRootView(): string;
 
     /**
-     * @param       $component
-     * @param array $props
+     * @param       $component Component name.
+     * @param array $props     Component properties.
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */

--- a/Tests/InertiaTest.php
+++ b/Tests/InertiaTest.php
@@ -137,4 +137,25 @@ class InertiaTest extends TestCase
         $response = $this->inertia->render('Dashboard');
         $this->assertInstanceOf(Response::class, $response);
     }
+    
+    public function testViewDataSingle()
+    {
+        $this->inertia->setViewData('app_name', 'Testing App 1');
+        $this->inertia->setViewData('app_version', '1.0.0');
+        $this->assertEquals('Testing App 1', $this->inertia->getViewData('app_name'));
+        $this->assertEquals('1.0.0', $this->inertia->getViewData('app_version'));
+    }
+
+    public function testViewDataMultiple()
+    {
+        $this->inertia->setViewData('app_name', 'Testing App 2');
+        $this->inertia->setViewData('app_version', '2.0.0');
+        $this->assertEquals(
+            [
+                'app_version' => '2.0.0',
+                'app_name'    => 'Testing App 2',
+            ],
+            $this->inertia->getViewData()
+        );
+    }
 }

--- a/Tests/InertiaTest.php
+++ b/Tests/InertiaTest.php
@@ -22,7 +22,7 @@ class InertiaTest extends TestCase
 
     public function setUp()
     {
-        $this->environment = \Mockery::mock(Environment::class);
+        $this->environment  = \Mockery::mock(Environment::class);
         $this->requestStack = \Mockery::mock(RequestStack::class);
 
         $this->inertia = new Inertia('app.twig.html', $this->environment, $this->requestStack);
@@ -84,7 +84,7 @@ class InertiaTest extends TestCase
         $this->inertia = new Inertia('app.twig.html', $this->environment, $this->requestStack);
 
         $response = $this->inertia->render('Dashboard', ['test' => 123]);
-        $data = json_decode($response->getContent(), true);
+        $data     = json_decode($response->getContent(), true);
         $this->assertEquals(['test' => 123], $data['props']);
     }
 
@@ -100,7 +100,7 @@ class InertiaTest extends TestCase
         $this->inertia->share('app_version', '2.0.0');
 
         $response = $this->inertia->render('Dashboard', ['test' => 123]);
-        $data = json_decode($response->getContent(), true);
+        $data     = json_decode($response->getContent(), true);
         $this->assertEquals(['test' => 123, 'app_name' => 'Testing App 3', 'app_version' => '2.0.0'], $data['props']);
     }
 

--- a/Twig/InertiaExtension.php
+++ b/Twig/InertiaExtension.php
@@ -22,6 +22,6 @@ class InertiaExtension extends AbstractExtension
 
     public function inertiaFunction($page)
     {
-        return new Markup('<div id="app" data-page="'.htmlspecialchars(json_encode($page)).'"></div>', 'UTF-8');
+        return new Markup('<div id="app" data-page="' . htmlspecialchars(json_encode($page)) . '"></div>', 'UTF-8');
     }
 }


### PR DESCRIPTION
See https://github.com/rompetomp/inertia-bundle/issues/7. 
Works the same way as shared properties. 

Single: `$inertia->render('component', [ 'prop' => 'value' ], [ 'viewData' => 'value']);`
Multiple (in Controller Event): `$this->inertia->setViewData('viewData', 'value');`