### PR TITLE
Support for the Serializer component

### DIFF
--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -12,6 +12,8 @@ services:
     public: false
     tags:
       - { name: twig.extension }
+    arguments:
+      $container: '@service_container'
 
   Rompetomp\InertiaBundle\EventListener\InertiaListener:
     tags:

--- a/Service/Inertia.php
+++ b/Service/Inertia.php
@@ -21,6 +21,9 @@ class Inertia implements InertiaInterface
     /** @var array */
     protected $sharedViewData = [];
 
+    /** @var array */
+    protected $sharedContext = [];
+
     /** @var \Symfony\Component\HttpFoundation\RequestStack */
     protected $requestStack;
 
@@ -69,6 +72,20 @@ class Inertia implements InertiaInterface
         return $this->sharedViewData;
     }
 
+    public function context(string $key, $value = null): void
+    {
+        $this->sharedContext[$key] = $value;
+    }
+
+    public function getContext(string $key = null)
+    {
+        if ($key) {
+            return $this->sharedContext[$key] ?? null;
+        }
+
+        return $this->sharedContext;
+    }
+
     public function version(string $version): void
     {
         $this->version = $version;
@@ -84,8 +101,9 @@ class Inertia implements InertiaInterface
         return $this->rootView;
     }
 
-    public function render($component, $props = [], $viewData = []): Response
+    public function render($component, $props = [], $viewData = [], $context = []): Response
     {
+        $context = array_merge($this->sharedContext, $context);
         $viewData = array_merge($this->sharedViewData, $viewData);
         $props = array_merge($this->sharedProps, $props);
         $request = $this->requestStack->getCurrentRequest();
@@ -112,7 +130,7 @@ class Inertia implements InertiaInterface
         }
 
         $response = new Response();
-        $response->setContent($this->engine->render($this->rootView, compact('page', 'viewData')));
+        $response->setContent($this->engine->render($this->rootView, compact('page', 'viewData', 'context')));
 
         return $response;
     }

--- a/Service/InertiaInterface.php
+++ b/Service/InertiaInterface.php
@@ -49,6 +49,21 @@ interface InertiaInterface
     public function version(string $version): void;
 
     /**
+     * Adds a context for the serializer.
+     *
+     * @param string $key
+     * @param mixed  $value
+     */
+    public function context(string $key, $value = null): void;
+
+    /**
+     * @param string|null $key
+     *
+     * @return mixed
+     */
+    public function getContext(string $key = null);
+
+    /**
      * @return string
      */
     public function getVersion(): ?string;
@@ -62,8 +77,9 @@ interface InertiaInterface
      * @param string $component component name
      * @param array  $props     component properties
      * @param array  $viewData  templating view data
+     * @param array  $context   serialization context
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function render($component, $props = [], $viewData = []): Response;
+    public function render($component, $props = [], $viewData = [], $context = []): Response;
 }

--- a/Tests/InertiaTest.php
+++ b/Tests/InertiaTest.php
@@ -158,4 +158,21 @@ class InertiaTest extends TestCase
             $this->inertia->getViewData()
         );
     }
+
+    public function testContextSingle()
+    {
+        $this->inertia->context('groups', [ 'group1', 'group2' ]);
+        $this->assertEquals([ 'group1', 'group2' ], $this->inertia->getContext('groups'));
+    }
+
+    public function testContextMultiple()
+    {
+        $this->inertia->context('groups', [ 'group1', 'group2' ]);
+        $this->assertEquals(
+            [
+                'groups'    =>  [ 'group1', 'group2' ],
+            ],
+            $this->inertia->getContext()
+        );
+    }
 }

--- a/Twig/InertiaExtension.php
+++ b/Twig/InertiaExtension.php
@@ -11,13 +11,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Class InertiaExtension.
  *
- * @author  Hannes Vermeire <hannes@codedor.be>²²
+ * @author  Hannes Vermeire <hannes@codedor.be>
  *
  * @since   2019-08-09
  */
 class InertiaExtension extends AbstractExtension
 {
-
     /**
      * @var ContainerInterface
      */

--- a/Twig/InertiaExtension.php
+++ b/Twig/InertiaExtension.php
@@ -2,26 +2,47 @@
 
 namespace Rompetomp\InertiaBundle\Twig;
 
-use Twig\Extension\AbstractExtension;
 use Twig\Markup;
 use Twig\TwigFunction;
+use Twig\Extension\AbstractExtension;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Class InertiaExtension.
  *
- * @author  Hannes Vermeire <hannes@codedor.be>
+ * @author  Hannes Vermeire <hannes@codedor.be>²²
  *
  * @since   2019-08-09
  */
 class InertiaExtension extends AbstractExtension
 {
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
     public function getFunctions()
     {
         return [new TwigFunction('inertia', [$this, 'inertiaFunction'])];
     }
 
-    public function inertiaFunction($page)
+    public function inertiaFunction($page, $context = [])
     {
-        return new Markup('<div id="app" data-page="'.htmlspecialchars(json_encode($page)).'"></div>', 'UTF-8');
+        if ($this->container->has('serializer')) {
+            $json = $this->container->get('serializer')->serialize($page, 'json', array_merge([
+                'json_encode_options' => JsonResponse::DEFAULT_ENCODING_OPTIONS,
+            ], $context));
+        } else {
+            $json = json_encode($page);
+        }
+
+        return new Markup('<div id="app" data-page="'.htmlspecialchars($json).'"></div>', 'UTF-8');
     }
 }


### PR DESCRIPTION
I think integrating the serializer component when it's available is a good idea. 

I took inspiration from the `json()` method of Symfony's `ControllerTrait` and put that in the `Twig\InertiaExtension` class. I also added a third shared variable for giving context to the serialization. 

Basically, if the serialization component is not provided, the Twig extension still uses `json_encode`. But when it's available, it serializes the `$page` with the given `$context`. 

The context must be added as a parameter in the Twig template:

```twig
{% app.html.twig %}
{{ inertia(page, context) }}
```

And you can either add shared context in an event listener like this: 

```php
// ControlerSubscriber.php
$this->inertia->context('groups', [ 'id_only' ]);
```

Or add a specific context with the `render` method: 

```php
// SomeController.php
return $this->inertia->render('Dashboard', [ 'clients' => $clients ], [], [ 'groups' => 'id_only' ]);
```