### PR TITLE
(Needs testing) Serialization fix for X-Inertia requests

### DIFF
--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -5,6 +5,7 @@ services:
     arguments:
       $engine: '@twig'
       $requestStack: '@request_stack'
+      $serializer: '@serializer'
   Rompetomp\InertiaBundle\Service\InertiaInterface: '@rompetomp_inertia.inertia'
 
   rompetomp_inertia.twig_extension:
@@ -12,8 +13,6 @@ services:
     public: false
     tags:
       - { name: twig.extension }
-    arguments:
-      $container: '@service_container'
 
   Rompetomp\InertiaBundle\EventListener\InertiaListener:
     tags:

--- a/Service/Inertia.php
+++ b/Service/Inertia.php
@@ -43,10 +43,10 @@ class Inertia implements InertiaInterface
      */
     public function __construct(string $rootView, Environment $engine, RequestStack $requestStack, ?SerializerInterface $serializer = null)
     {
-        $this->engine       = $engine;
-        $this->rootView     = $rootView;
+        $this->engine = $engine;
+        $this->rootView = $rootView;
         $this->requestStack = $requestStack;
-        $this->serializer   = $serializer;
+        $this->serializer = $serializer;
     }
 
     public function share(string $key, $value = null): void
@@ -108,13 +108,13 @@ class Inertia implements InertiaInterface
 
     public function render($component, $props = [], $viewData = [], $context = []): Response
     {
-        $context  = array_merge($this->sharedContext, $context);
+        $context = array_merge($this->sharedContext, $context);
         $viewData = array_merge($this->sharedViewData, $viewData);
-        $props    = array_merge($this->sharedProps, $props);
-        $request  = $this->requestStack->getCurrentRequest();
-        $url      = $request->getRequestUri();
+        $props = array_merge($this->sharedProps, $props);
+        $request = $this->requestStack->getCurrentRequest();
+        $url = $request->getRequestUri();
 
-        $only  = array_filter(explode(',', $request->headers->get('X-Inertia-Partial-Data')));
+        $only = array_filter(explode(',', $request->headers->get('X-Inertia-Partial-Data')));
         $props = ($only && $request->headers->get('X-Inertia-Partial-Component') === $component)
             ? self::array_only($props, $only) : $props;
 
@@ -125,7 +125,7 @@ class Inertia implements InertiaInterface
         });
 
         $version = $this->version;
-        $page    = $this->serialize(compact('component', 'props', 'url', 'version'), $context);
+        $page = $this->serialize(compact('component', 'props', 'url', 'version'), $context);
 
         if ($request->headers->get('X-Inertia')) {
             return new JsonResponse($page, 200, [
@@ -148,7 +148,7 @@ class Inertia implements InertiaInterface
      * @param array $page
      * @param array $context
      *
-     * @return array Returns a decoded array of the previously JSON-encoded data, so it can safely be given to {@see JsonResponse}.
+     * @return array returns a decoded array of the previously JSON-encoded data, so it can safely be given to {@see JsonResponse}.
      */
     private function serialize(array $page, $context = []): array
     {

--- a/Service/Inertia.php
+++ b/Service/Inertia.php
@@ -129,7 +129,7 @@ class Inertia implements InertiaInterface
 
         if ($request->headers->get('X-Inertia')) {
             return new JsonResponse($page, 200, [
-                'Vary'      => 'Accept',
+                'Vary' => 'Accept',
                 'X-Inertia' => true,
             ]);
         }
@@ -148,7 +148,7 @@ class Inertia implements InertiaInterface
      * @param array $page
      * @param array $context
      *
-     * @return array returns a decoded array of the previously JSON-encoded data, so it can safely be given to {@see JsonResponse}.
+     * @return array @return array returns a decoded array of the previously JSON-encoded data, so it can safely be given to {@see JsonResponse}
      */
     private function serialize(array $page, $context = []): array
     {

--- a/Tests/InertiaTest.php
+++ b/Tests/InertiaTest.php
@@ -19,13 +19,16 @@ class InertiaTest extends TestCase
     private $environment;
     /** @var \Mockery\LegacyMockInterface|\Mockery\MockInterface|\Symfony\Component\HttpFoundation\RequestStack */
     private $requestStack;
+    /** @var \Mockery\LegacyMockInterface|\Mockery\MockInterface|\Symfony\Component\Serializer\Serializer|null */
+    private $serializer;
 
     public function setUp()
     {
+        $this->serializer   = null;
         $this->environment  = \Mockery::mock(Environment::class);
         $this->requestStack = \Mockery::mock(RequestStack::class);
 
-        $this->inertia = new Inertia('app.twig.html', $this->environment, $this->requestStack);
+        $this->inertia = new Inertia('app.twig.html', $this->environment, $this->requestStack, $this->serializer);
     }
 
     public function testSharedSingle()
@@ -68,7 +71,7 @@ class InertiaTest extends TestCase
         $mockRequest->allows()->getRequestUri()->andReturns('https://example.test');
         $this->requestStack->allows()->getCurrentRequest()->andReturns($mockRequest);
 
-        $this->inertia = new Inertia('app.twig.html', $this->environment, $this->requestStack);
+        $this->inertia = new Inertia('app.twig.html', $this->environment, $this->requestStack, $this->serializer);
 
         $response = $this->inertia->render('Dashboard');
         $this->assertInstanceOf(JsonResponse::class, $response);
@@ -81,7 +84,7 @@ class InertiaTest extends TestCase
         $mockRequest->allows()->getRequestUri()->andReturns('https://example.test');
         $this->requestStack->allows()->getCurrentRequest()->andReturns($mockRequest);
 
-        $this->inertia = new Inertia('app.twig.html', $this->environment, $this->requestStack);
+        $this->inertia = new Inertia('app.twig.html', $this->environment, $this->requestStack, $this->serializer);
 
         $response = $this->inertia->render('Dashboard', ['test' => 123]);
         $data     = json_decode($response->getContent(), true);
@@ -95,7 +98,7 @@ class InertiaTest extends TestCase
         $mockRequest->allows()->getRequestUri()->andReturns('https://example.test');
         $this->requestStack->allows()->getCurrentRequest()->andReturns($mockRequest);
 
-        $this->inertia = new Inertia('app.twig.html', $this->environment, $this->requestStack);
+        $this->inertia = new Inertia('app.twig.html', $this->environment, $this->requestStack, $this->serializer);
         $this->inertia->share('app_name', 'Testing App 3');
         $this->inertia->share('app_version', '2.0.0');
 
@@ -111,7 +114,7 @@ class InertiaTest extends TestCase
         $mockRequest->allows()->getRequestUri()->andReturns('https://example.test');
         $this->requestStack->allows()->getCurrentRequest()->andReturns($mockRequest);
 
-        $this->inertia = new Inertia('app.twig.html', $this->environment, $this->requestStack);
+        $this->inertia = new Inertia('app.twig.html', $this->environment, $this->requestStack, $this->serializer);
 
         /** @var JsonResponse $response */
         $response = $this->inertia->render('Dashboard', ['test' => function () {
@@ -132,7 +135,7 @@ class InertiaTest extends TestCase
 
         $this->environment->allows('render')->andReturn('<div>123</div>');
 
-        $this->inertia = new Inertia('app.twig.html', $this->environment, $this->requestStack);
+        $this->inertia = new Inertia('app.twig.html', $this->environment, $this->requestStack, $this->serializer);
 
         $response = $this->inertia->render('Dashboard');
         $this->assertInstanceOf(Response::class, $response);

--- a/Twig/InertiaExtension.php
+++ b/Twig/InertiaExtension.php
@@ -22,6 +22,6 @@ class InertiaExtension extends AbstractExtension
 
     public function inertiaFunction($page)
     {
-        return new Markup('<div id="app" data-page="' . htmlspecialchars(json_encode($page)) . '"></div>', 'UTF-8');
+        return new Markup('<div id="app" data-page="'.htmlspecialchars(json_encode($page)).'"></div>', 'UTF-8');
     }
 }

--- a/Twig/InertiaExtension.php
+++ b/Twig/InertiaExtension.php
@@ -2,11 +2,9 @@
 
 namespace Rompetomp\InertiaBundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Twig\Markup;
 use Twig\TwigFunction;
-use Twig\Extension\AbstractExtension;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Class InertiaExtension.
@@ -17,31 +15,13 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class InertiaExtension extends AbstractExtension
 {
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
-
-    public function __construct(ContainerInterface $container)
-    {
-        $this->container = $container;
-    }
-
     public function getFunctions()
     {
         return [new TwigFunction('inertia', [$this, 'inertiaFunction'])];
     }
 
-    public function inertiaFunction($page, $context = [])
+    public function inertiaFunction($page)
     {
-        if ($this->container->has('serializer')) {
-            $json = $this->container->get('serializer')->serialize($page, 'json', array_merge([
-                'json_encode_options' => JsonResponse::DEFAULT_ENCODING_OPTIONS,
-            ], $context));
-        } else {
-            $json = json_encode($page);
-        }
-
-        return new Markup('<div id="app" data-page="'.htmlspecialchars($json).'"></div>', 'UTF-8');
+        return new Markup('<div id="app" data-page="' . htmlspecialchars(json_encode($page)) . '"></div>', 'UTF-8');
     }
 }


### PR DESCRIPTION
I made a mistake in #10. I allowed the usage of the serializer component, but I only implemented it for the first requests, [the ones that use Twig](https://github.com/rompetomp/inertia-bundle/pull/10/commits/1d328ab08934e87d05cd964633b19f538ae28e59#diff-40fe6fa51ee72630ed12a2bd2a76ade9R36-R46). 

Because of that, the subsequent requests made with Inertia would not be serialized. To fix this, I had to move the serialization [inside the implementation of `InertiaInterface`](https://github.com/rompetomp/inertia-bundle/commit/96d8831031b4ef6f76e07071cfa3f8ffd77ba08f#diff-7bb7b343c48f74d8643d8d6fca1e39d5R128). 

Also, instead of injecting the container, I injected directly the serializer. I'm not sure how DependencyInjection will behave if the serializer is not installed, although tests are passing.

That being said, I could not write specific tests because I lack knowledge in Mockery, and this is needed to fake a use of the `Serializer` object. 

If you could make tests and correct the service definition if I edited it in the wrong way because of the optional nature of the serializer service, it would be great. Thank you!