### PR TITLE
Update the Web Debug Toolbar after AJAX requests

### DIFF
--- a/EventListener/InertiaListener.php
+++ b/EventListener/InertiaListener.php
@@ -17,9 +17,15 @@ class InertiaListener
      */
     protected $inertia;
 
-    public function __construct(InertiaInterface $inertia)
+    /**
+     * @var bool
+     */
+    protected $debug;
+
+    public function __construct(InertiaInterface $inertia, bool $debug)
     {
         $this->inertia = $inertia;
+        $this->debug = $debug;
     }
 
     public function onKernelRequest(RequestEvent $event)
@@ -42,6 +48,11 @@ class InertiaListener
         if (!$event->getRequest()->headers->get('X-Inertia')) {
             return;
         }
+
+        if ($this->debug && $event->getRequest()->isXmlHttpRequest()) {
+            $event->getResponse()->headers->set('Symfony-Debug-Toolbar-Replace', 1);
+        }
+
         if ($event->getResponse()->isRedirect()
             && 302 === $event->getResponse()->getStatusCode()
             && in_array($event->getRequest()->getMethod(), ['PUT', 'PATCH', 'DELETE'])

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -20,3 +20,4 @@ services:
       - { name: kernel.event_listener, event: kernel.response }
     arguments:
       $inertia: '@rompetomp_inertia.inertia'
+      $debug: '%kernel.debug%'


### PR DESCRIPTION
`InertiaListener` now adds the `Symfony-Debug-Toolbar-Replace` header for AJAX requests when the Kernel runs in debug mode.

As suggested in #14.