### PR TITLE
Fix Deprecation warning

### DIFF
--- a/Twig/InertiaExtension.php
+++ b/Twig/InertiaExtension.php
@@ -15,7 +15,7 @@ use Twig\TwigFunction;
  */
 class InertiaExtension extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [new TwigFunction('inertia', [$this, 'inertiaFunction'])];
     }


### PR DESCRIPTION
Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "Rompetomp\InertiaBundle\Twig\InertiaExtension" now to avoid errors or add an explicit @return annotation to suppress this message.