### PR TITLE
Fix ERR_REQUIRE_ESM when running ssr.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ touch webpack.ssr.mix.js
 Here is an example file for `webpack.ssr.config.js`
 ```js
 const Encore = require('@symfony/webpack-encore')
-const webpackNodeExternals = require('webpack-node-externals')
+const nodeExternals = require('webpack-node-externals')
 const path = require('path')
 
 if (!Encore.isRuntimeEnvironmentConfigured()) {
@@ -343,10 +343,14 @@ Encore
     .enableSourceMaps(!Encore.isProduction())
     .enableVersioning(Encore.isProduction())
     .enableSassLoader()
+    .addExternals(
+        nodeExternals({
+              allowlist: ['@inertiajs/vue3'],
+        }),
+    );
 
 const config = Encore.getWebpackConfig();
-config.target = 'node';
-config.externals = [webpackNodeExternals()];
+config.externalsPresets = { node: true };
 
 module.exports = config
 ```


### PR DESCRIPTION
With Inertia v1.0, an error occured while running ssr.js: 

```
$ node public/build-ssr/ssr.js 

/public/build-ssr/ssr.js:29
module.exports = require("@inertiajs/core");
                 ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /node_modules/@inertiajs/core/dist/index.js from /public/build-ssr/ssr.js not supported.
index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead either rename index.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /node_modules/@inertiajs/core/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

    at @inertiajs/core (/public/build-ssr/ssr.js:29:18)
    at __webpack_require__ (/public/build-ssr/ssr.js:139:41)
    at ./node_modules/@inertiajs/vue3/dist/index.esm.js (/public/build-ssr/ssr.js:105:73)
    at __webpack_require__ (/public/build-ssr/ssr.js:139:41)
    at /public/build-ssr/ssr.js:195:73 {
  code: 'ERR_REQUIRE_ESM'
}
```

The problem is solved by adding @inertiajs/vue3 package to webpack-node-externals allowlist.

I took the opportunity to use the [addExternals](https://symfony.com/doc/current/frontend/encore/advanced-config.html#excluding-some-dependencies-from-output-bundles) function of Webpack Encore (instead of config.externals) and [externalsPresets](https://webpack.js.org/configuration/externals/#externalspresets) option of Webpack.

